### PR TITLE
Bump CLJS compiler to 1.9.542.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "Inspector tools for clojure[script]"
   :url "https://github.com/viebel/gadjett"
   :dependencies [[org.clojure/clojure "1.9.0-alpha14"]
-                 [org.clojure/clojurescript "1.9.227"]
+                 [org.clojure/clojurescript "1.9.542"]
                  [org.clojure/core.match "0.3.0-alpha4"]
                  [org.clojure/core.async "0.3.442"]]
   :profiles {:codox {:dependencies [[viebel/codox-klipse-theme "0.0.5"]]

--- a/src/gadjett/spec_test_utils.clj
+++ b/src/gadjett/spec_test_utils.clj
@@ -1,8 +1,8 @@
 (ns gadjett.spec-test-utils
   (:require [clojure.pprint :as pprint]
-            [clojure.spec :as s]
+            [clojure.spec.alpha :as s]
             [clojure.test :refer [is]]
-            [clojure.spec.test :as stest]))
+            [clojure.spec.test.alpha :as stest]))
 
 
 (defn summarize-results' [spec-check]


### PR DESCRIPTION
This CLJS compiler is after the move from clojure.spec to
clojure.spec.alpha. The version of gadjett should probably be bumped.